### PR TITLE
Fix blog markup and typo

### DIFF
--- a/src/content/blog/letter-to-aui.md
+++ b/src/content/blog/letter-to-aui.md
@@ -47,7 +47,7 @@ At AUI, you are fortunate to come from an institution that has established itsel
 
 When you carry forward your curiosity, resilience, and hard-earned skills, you should walk into any global arena with the same conviction and confidence as your peers from the world’s most prestigious institutions — knowing that your voice, your ideas, and your work belong there.
 
-**Potential Alone Is Not Engough**
+**Potential Alone Is Not Enough**
 
 Three qualities have stood out to me across all the people I've admired and worked with:
 
@@ -57,7 +57,7 @@ Not chasing salaries, titles, accolades, promotions or quick social validation �
 - **They all stubbornly believe that they can.**  
 A quiet, stubborn certainty that your ideas, your voice, and your work have value — even when no one else validates it yet.  The Moroccan word *jebha* comes to mind. Having the *jebha* (the stubborn forehead, the resolve) is essential — but it only matters if it is backed by hard work, humility, and a desire to create, not just to compete, or pretend.
 
-- **They all pocess the curiosity, grit, and perseverance to make it real.**  
+- **They all possess the curiosity, grit, and perseverance to make it real.**
 The discipline to show up when it's hard, to keep building when it's thankless, to keep learning and fail fast, and to endure long enough to turn conviction into contribution.
 
 Curiosity, grit, perseverance, humility, and purpose.  These are some of the fundamental ingredients for the magic to happen.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -86,7 +86,7 @@ const posts = await getCollection('blog');
   <section id="blog" class="snap-start relative min-h-screen px-4 py-28 bg-[#FAF7F2] border-t border-[#e4e0db]">
     <div class="prose prose-neutral max-w-prose mx-auto space-y-6 text-base sm:text-lg leading-relaxed text-center">
       <h2 class="text-2xl sm:text-3xl font-bold text-center mb-6">Ideas & Insights</h2>
-      <div "space-y-4">
+      <div class="space-y-4">
         <p>I started writing publicly to reflect on the journey that
           shaped me — from Morocco to Microsoft, from engineering to leadership, and from quietly building to mentoring
           and giving back.</p>


### PR DESCRIPTION
## Summary
- fix missing class attribute in blog section
- correct typos in the first blog post

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e0d573ad48330bb96f9825f169542